### PR TITLE
fix: cdn_vue_version

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Let's FUKUOKA</title>
     <link rel="stylesheet" href="style.css">
-	<script src="https://unpkg.com/vue"></script>
+	<script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
 	<script src="https://unpkg.com/http-vue-loader"></script>
     <link rel="icon" type="image/x-icon" href="icon.png">
  	<meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
vueのバージョン指定がされてなかったら、
vue2, 3で記法が変わったあたりの問題でvueがバグっとる

とりあえず2系の最新を指定したので動くはず。

vue3の記法に合わせて書き直すのかどうかは要検討ということで